### PR TITLE
Clone moment object before formatting as name

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -215,7 +215,7 @@ export default class PeriodicNotesPlugin extends Plugin {
   ): Promise<TFile> {
     const config = this.calendarSetManager.getActiveConfig(granularity);
     const format = this.calendarSetManager.getFormat(granularity);
-    const filename = date.format(format);
+    const filename = date.clone().format(format);
     const templateContents = await getTemplateContents(this.app, config.templatePath);
     const renderedContents = applyTemplateTransformations(
       filename,


### PR DESCRIPTION
This prevents mutating date object when using as file name, so that it can still be used inside the template files.

This should fix #171 

## The problem
A moment object is mutable. This means that when using `format` on a moment object, it changes the actual object, rather than returning a copy. 

As a result, the date object may be changed to something like `2023-W11` and overwrites the `date` object used in the template files. This means doing something like `{{date:MM}}` in a week template does work anymore.

Using `clone` _should_ fix this.

@liamcain It would be great if you could have a look and merge this, as the bug basically makes any thing but date files in the beta unusable if you need the `date` object.