### PR TITLE
Adds a Create Note command (doesn't open note) & an API for userscript consumption

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,31 @@
+import PeriodicNotesPlugin from "./main"
+import { Granularity } from "./types"
+
+
+export default class PeriodicNotesAPI {
+  static instance: PeriodicNotesAPI
+
+  public static get(plugin: PeriodicNotesPlugin) {
+    return {
+      getGranularities() {
+        return plugin.calendarSetManager.getActiveGranularities()
+      },
+      async createPeriodicNote(granularity: Granularity, openNote = false, date = window.moment()) {
+        await plugin.createOrReturnPeriodicNote(
+          granularity,
+          date
+        );
+
+        if(openNote) {
+          plugin.openPeriodicNote(granularity, date)
+        }
+      },
+      getPeriodicNote(granularity: Granularity, date = window.moment()) {
+        return plugin.getPeriodicNote(
+          granularity,
+          date
+        );
+      }
+    }
+  }
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ interface IDisplayConfig {
   periodicity: string;
   relativeUnit: string;
   labelOpenPresent: string;
+  labelCreatePresent: string;
 }
 
 export const displayConfigs: Record<Granularity, IDisplayConfig> = {
@@ -14,26 +15,31 @@ export const displayConfigs: Record<Granularity, IDisplayConfig> = {
     periodicity: "daily",
     relativeUnit: "today",
     labelOpenPresent: "Open today's daily note",
+    labelCreatePresent: "Create today's daily note",
   },
   week: {
     periodicity: "weekly",
     relativeUnit: "this week",
     labelOpenPresent: "Open this week's note",
+    labelCreatePresent: "Create this week's note",
   },
   month: {
     periodicity: "monthly",
     relativeUnit: "this month",
     labelOpenPresent: "Open this month's note",
+    labelCreatePresent: "Create this month's note",
   },
   quarter: {
     periodicity: "quarterly",
     relativeUnit: "this quarter",
     labelOpenPresent: "Open this quarter's note",
+    labelCreatePresent: "Create this quarter's note",
   },
   year: {
     periodicity: "yearly",
     relativeUnit: "this year",
     labelOpenPresent: "Open this year's note",
+    labelCreatePresent: "Create this year's note",
   },
 };
 
@@ -100,7 +106,13 @@ export function getCommands(
       name: config.labelOpenPresent,
       callback: () => plugin.openPeriodicNote(granularity, window.moment()),
     },
-
+    {
+      id: `create-${config.periodicity}-note`,
+      name: config.labelCreatePresent,
+      callback: async () => {
+        await plugin.createOrReturnPeriodicNote(granularity, window.moment())
+      },
+    },
     {
       id: `next-${config.periodicity}-note`,
       name: `Jump forwards to closest ${config.periodicity} note`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import type { Moment } from "moment";
 import { addIcon, Plugin, TFile } from "obsidian";
 import { writable, type Writable } from "svelte/store";
 
+import PeriodicNotesAPI from "./api";
 import { PeriodicNotesCache, type PeriodicNoteCachedMetadata } from "./cache";
 import CalendarSetManager, {
   DEFAULT_CALENDARSET_ID,
@@ -58,6 +59,8 @@ export default class PeriodicNotesPlugin extends Plugin {
   public calendarSetManager: CalendarSetManager;
   private timelineManager: TimelineManager;
 
+  api: PeriodicNotesAPI
+
   unload(): void {
     super.unload();
     this.timelineManager?.cleanup();
@@ -70,6 +73,7 @@ export default class PeriodicNotesPlugin extends Plugin {
 
     initializeLocaleConfigOnce(this.app);
 
+    this.api = PeriodicNotesAPI.get(this)
     this.ribbonEl = null;
     this.calendarSetManager = new CalendarSetManager(this);
     this.cache = new PeriodicNotesCache(this.app, this);
@@ -228,6 +232,22 @@ export default class PeriodicNotesPlugin extends Plugin {
     return this.app.vault.create(destPath, renderedContents);
   }
 
+  public async createOrReturnPeriodicNote(
+    granularity: Granularity,
+    date: Moment,
+    calendarSet?: string
+  ): Promise<TFile> {
+    let file = this.cache.getPeriodicNote(
+      calendarSet ?? this.calendarSetManager.getActiveId(),
+      granularity,
+      date
+    );
+    if (!file) {
+      file = await this.createPeriodicNote(granularity, date);
+    }
+    return file
+  }
+
   public getPeriodicNote(granularity: Granularity, date: Moment): TFile | null {
     return this.cache.getPeriodicNote(
       this.calendarSetManager.getActiveId(),
@@ -273,14 +293,7 @@ export default class PeriodicNotesPlugin extends Plugin {
   ): Promise<void> {
     const { inNewSplit = false, calendarSet } = opts ?? {};
     const { workspace } = this.app;
-    let file = this.cache.getPeriodicNote(
-      calendarSet ?? this.calendarSetManager.getActiveId(),
-      granularity,
-      date
-    );
-    if (!file) {
-      file = await this.createPeriodicNote(granularity, date);
-    }
+    const file = await this.createOrReturnPeriodicNote(granularity, date, calendarSet);
 
     const leaf = inNewSplit ? workspace.splitActiveLeaf() : workspace.getUnpinnedLeaf();
     await leaf.openFile(file, { active: true });


### PR DESCRIPTION
I found myself wanting to create periodic notes programatically so that I could do some other automations on them.

I've created a public API that exposes some functions and added a command that creates a note without opening it.

The labels might need to be updated to make it clear between the distinction of open vs create

If you're happy with this I can update the docs with new features.