### PR TITLE
Fix Issue with Inconsistent Ribbon Icon Positioning on Load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,9 @@ export default class PeriodicNotesPlugin extends Plugin {
 
     this.openPeriodicNote = this.openPeriodicNote.bind(this);
     this.addSettingTab(new PeriodicNotesSettingsTab(this.app, this));
+    
+    this.configureRibbonIcons();
+    this.configureCommands();
 
     addIcon("calendar-day", calendarDayIcon);
     addIcon("calendar-week", calendarWeekIcon);
@@ -109,9 +112,6 @@ export default class PeriodicNotesPlugin extends Plugin {
     });
 
     this.app.workspace.onLayoutReady(() => {
-      this.configureRibbonIcons();
-      this.configureCommands();
-
       const startupNoteConfig = findStartupNoteConfig(this.settings);
       if (startupNoteConfig) {
         this.openPeriodicNote(startupNoteConfig.granularity, window.moment(), {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,6 +64,12 @@ export default class PeriodicNotesPlugin extends Plugin {
   }
 
   async onload(): Promise<void> {
+    addIcon("calendar-day", calendarDayIcon);
+    addIcon("calendar-week", calendarWeekIcon);
+    addIcon("calendar-month", calendarMonthIcon);
+    addIcon("calendar-quarter", calendarQuarterIcon);
+    addIcon("calendar-year", calendarYearIcon);
+
     this.settings = writable<ISettings>();
     await this.loadSettings();
     this.register(this.settings.subscribe(this.onUpdateSettings.bind(this)));
@@ -80,12 +86,6 @@ export default class PeriodicNotesPlugin extends Plugin {
     
     this.configureRibbonIcons();
     this.configureCommands();
-
-    addIcon("calendar-day", calendarDayIcon);
-    addIcon("calendar-week", calendarWeekIcon);
-    addIcon("calendar-month", calendarMonthIcon);
-    addIcon("calendar-quarter", calendarQuarterIcon);
-    addIcon("calendar-year", calendarYearIcon);
 
     this.addCommand({
       id: "show-date-switcher",


### PR DESCRIPTION
Fixes https://github.com/liamcain/obsidian-periodic-notes/issues/200

Prior to this code fix, the ribbon item would always be appended to the bottom—irrespective of users altering their position—due to being called within the `onLayoutReady()` func. The below screenshot highlights the `hiddenItems` object being altered upon reloading the application. 

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/7eb72ed8-c4b1-42ad-bad1-c30290ec4bcf">

Testing is simple, move the position of any periodic note ribbon item (whether on desktop or mobile), and reload the application. Viewing the position having been altered.

Moving both the `configureRibbonIcons()` and `this.configureCommands()` funcs into `onload()` alleviates the alteration of ribbon item position on both desktop and mobile—after having tested both.  Additionally, after some market research, I found no other plugins adding ribbon items in `onLayoutReady()`, rather, within `onload()`; which is where I found this simple fix. 

Furthermore, I also altered the loading of icons—`addIcon()`—to run prior to `onLayoutReady()`, thus removing the flash seen below. `Reload app without saving` was run to visualise the effect. 

![Jul-17-2024 18-59-22](https://github.com/user-attachments/assets/6e213079-853a-439f-b81d-2ea7cf9a7989)

After moving the `addIcon()` funcs to run prior to `onLayoutReady()` the issue is no longer apparent and icons load instantaneously. 

![Jul-17-2024 18-59-31](https://github.com/user-attachments/assets/3c43ddfb-aaf9-4aa1-a0cf-0a33d71c86c7)
