### PR TITLE
feat: add timeline controls and highlighting

### DIFF
--- a/src/timeline/Icon.svelte
+++ b/src/timeline/Icon.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { setIcon } from "obsidian";
   import { onMount } from "svelte";
+  export let icon: string;
 
   let iconEl: HTMLElement;
 
   onMount(() => {
-    setIcon(iconEl, "forward-arrow", 12);
+    setIcon(iconEl, icon, 12);
   });
 </script>
 


### PR DESCRIPTION
I've changed the cache functionality to also add an entry for the CanonicalDateString. 

This would probably be better as a seperate map that refrences the FilePath (thoughts appreciated). This is used for finding notes by date to make highlighting easier in the timeline

The controls are simple enough. Need a bit of CSS to match the rest of the style

<img width="263" alt="Screenshot 2024-07-21 at 21 52 05" src="https://github.com/user-attachments/assets/0fe79e27-83d5-4700-a921-ab2d38f88867">
