### PR TITLE
feat: Add CLI handlers for silent periodic note creation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -130,22 +130,33 @@ export default class PeriodicNotesPlugin extends Plugin {
       const description = config.labelOpenPresent.replace("Open", "Create/open");
       const label = `${config.periodicity.charAt(0).toUpperCase()}${config.periodicity.slice(1)} notes`;
 
-      this.registerCliHandler(command, description, null, async () => {
-        const activeGranularities = this.calendarSetManager.getActiveGranularities();
-        if (!activeGranularities.includes(granularity)) {
-          return `Warning: ${label} are not enabled. Enable in Settings → Periodic Notes.`;
-        }
+      this.registerCliHandler(
+        command,
+        description,
+        { open: { description: "Open the note in Obsidian", type: "boolean" } },
+        async (data) => {
+          const activeGranularities = this.calendarSetManager.getActiveGranularities();
+          if (!activeGranularities.includes(granularity)) {
+            return `Warning: ${label} are not enabled. Enable in Settings → Periodic Notes.`;
+          }
 
-        try {
-          const date = window.moment();
-          const file =
-            this.getPeriodicNote(granularity, date) ??
-            (await this.createPeriodicNote(granularity, date));
-          return file.path;
-        } catch (e) {
-          return `Error: ${e instanceof Error ? e.message : String(e)}`;
+          try {
+            const date = window.moment();
+            const file =
+              this.getPeriodicNote(granularity, date) ??
+              (await this.createPeriodicNote(granularity, date));
+
+            if (data?.open === "true") {
+              const leaf = this.app.workspace.getUnpinnedLeaf();
+              await leaf.openFile(file, { active: true });
+            }
+
+            return file.path;
+          } catch (e) {
+            return `Error: ${e instanceof Error ? e.message : String(e)}`;
+          }
         }
-      });
+      );
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import {
 import { CalendarSetSuggestModal } from "./switcher/calendarSetSwitcher";
 import { NLDNavigator } from "./switcher/switcher";
 import TimelineManager from "./timeline/manager";
-import type { Granularity } from "./types";
+import { granularities, type Granularity } from "./types";
 import {
   applyTemplateTransformations,
   getNoteCreationPath,
@@ -87,6 +87,8 @@ export default class PeriodicNotesPlugin extends Plugin {
     this.configureRibbonIcons();
     this.configureCommands();
 
+    this.registerCliHandlers();
+
     this.addCommand({
       id: "show-date-switcher",
       name: "Show date switcher...",
@@ -119,6 +121,32 @@ export default class PeriodicNotesPlugin extends Plugin {
         });
       }
     });
+  }
+
+  private registerCliHandlers(): void {
+    for (const granularity of granularities) {
+      const config = displayConfigs[granularity];
+      const command = `periodic-notes:${config.periodicity}`;
+      const description = config.labelOpenPresent.replace("Open", "Create/open");
+      const label = `${config.periodicity.charAt(0).toUpperCase()}${config.periodicity.slice(1)} notes`;
+
+      this.registerCliHandler(command, description, null, async () => {
+        const activeGranularities = this.calendarSetManager.getActiveGranularities();
+        if (!activeGranularities.includes(granularity)) {
+          return `Warning: ${label} are not enabled. Enable in Settings → Periodic Notes.`;
+        }
+
+        try {
+          const date = window.moment();
+          const file =
+            this.getPeriodicNote(granularity, date) ??
+            (await this.createPeriodicNote(granularity, date));
+          return file.path;
+        } catch (e) {
+          return `Error: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      });
+    }
   }
 
   private configureRibbonIcons() {

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -2,6 +2,29 @@ import "obsidian";
 import type { ILocaleOverride, IWeekStartOption } from "./settings";
 
 declare module "obsidian" {
+  interface CliData {
+    args: string[];
+    cwd: string;
+  }
+
+  type CliHandler = (args: CliData) => Promise<string>;
+
+  interface CliFlags {
+    [key: string]: {
+      description: string;
+      type?: "string" | "boolean";
+      required?: boolean;
+    };
+  }
+
+  interface Plugin {
+    registerCliHandler(
+      command: string,
+      description: string,
+      flags: CliFlags | null,
+      handler: CliHandler
+    ): void;
+  }
   interface IWeeklyNoteOptions {
     weeklyNoteFormat: string;
     weeklyNoteFolder: string;

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -5,6 +5,7 @@ declare module "obsidian" {
   interface CliData {
     args: string[];
     cwd: string;
+    [key: string]: string | string[] | undefined;
   }
 
   type CliHandler = (args: CliData) => Promise<string>;


### PR DESCRIPTION
## Summary
- Adds CLI handlers for programmatic creation of periodic notes without triggering the UI
- Handlers check enabled status dynamically at execution time
- Returns warning for disabled granularities, error for failures
- Returns existing note path if note already exists (no duplicates)
- Optional `open` flag to open the note in Obsidian UI

Fixes #262

## Commands
- `obsidian periodic-notes:daily` - Create/get today's daily note (silent)
- `obsidian periodic-notes:weekly` - Create/get this week's note (silent)
- `obsidian periodic-notes:monthly` - Create/get this month's note (silent)
- `obsidian periodic-notes:quarterly` - Create/get this quarter's note (silent)
- `obsidian periodic-notes:yearly` - Create/get this year's note (silent)

### Options
- `open` - Opens the note in Obsidian UI (e.g., `obsidian periodic-notes:daily open`)

## Test plan
- [x] Tested all 5 CLI handlers return correct paths
- [x] Verified existing notes are returned without duplication
- [x] Verified disabled granularities return warning message
- [x] Verified dynamic behavior (settings changes via UI take effect immediately)
- [x] Verified `open` flag opens note in Obsidian UI